### PR TITLE
Brighten background colors when molokai_original=1

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -131,7 +131,10 @@ end
 if &t_Co > 255
    if s:molokai_original == 1
       hi Normal                   ctermbg=234
-      hi CursorLine               ctermbg=235
+      hi CursorLine               ctermbg=235   cterm=none
+   else
+      hi Normal       ctermfg=252 ctermbg=233
+      hi CursorLine               ctermbg=234   cterm=none
    endif
    hi Boolean         ctermfg=135
    hi Character       ctermfg=144
@@ -208,9 +211,7 @@ if &t_Co > 255
    hi WarningMsg      ctermfg=231 ctermbg=238   cterm=bold
    hi WildMenu        ctermfg=81  ctermbg=16
 
-   hi Normal          ctermfg=252 ctermbg=233
    hi Comment         ctermfg=59
-   hi CursorLine                  ctermbg=234   cterm=none
    hi CursorColumn                ctermbg=234
    hi ColorColumn                 ctermbg=234
    hi LineNr          ctermfg=250 ctermbg=234


### PR DESCRIPTION
I find that these brighter background values for 256 color terminals are more consistent with the molokai_original colors.

I LOVE this color scheme. I use it everywhere. Thanks for all your hard work!

Justin
