### PR TITLE
Made those changes to the 256 color version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Just copy the file on your .vim/colors folder.
 If you prefer the scheme to match the original monokai background color, put this in your .vimrc file: 
     let g:molokai_original = 1
 
+There is also an alternative sheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
+    let g:rehash256 = 1

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -1,3 +1,4 @@
+  
 " Vim color file
 "
 " Author: Tomas Restrepo <tomas@winterdom.com>
@@ -75,7 +76,7 @@ hi PreProc         guifg=#A6E22E
 hi Question        guifg=#66D9EF
 hi Repeat          guifg=#F92672               gui=bold
 hi Search          guifg=#FFFFFF guibg=#455354
-" marks column
+" marks
 hi SignColumn      guifg=#A6E22E guibg=#232526
 hi SpecialChar     guifg=#F92672               gui=bold
 hi SpecialComment  guifg=#7E8E91               gui=bold
@@ -164,7 +165,7 @@ if &t_Co > 255
    hi Ignore          ctermfg=244 ctermbg=232
    hi IncSearch       ctermfg=193 ctermbg=16
 
-   hi Keyword         ctermfg=161               cterm=bold
+   hi keyword         ctermfg=161               cterm=bold
    hi Label           ctermfg=229               cterm=none
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
@@ -191,7 +192,12 @@ if &t_Co > 255
    hi SpecialChar     ctermfg=161               cterm=bold
    hi SpecialComment  ctermfg=245               cterm=bold
    hi Special         ctermfg=81 
-
+   if has("spell")
+       hi SpellBad                ctermbg=52   
+       hi SpellCap                ctermbg=17   
+       hi SpellLocal              ctermbg=17
+       hi SpellRare  ctermfg=none ctermbg=none  cterm=reverse
+   endif
    hi Statement       ctermfg=161               cterm=bold
    hi StatusLine      ctermfg=238 ctermbg=253
    hi StatusLineNC    ctermfg=244 ctermbg=232
@@ -216,5 +222,44 @@ if &t_Co > 255
    hi ColorColumn                 ctermbg=234
    hi LineNr          ctermfg=250 ctermbg=234
    hi NonText         ctermfg=59
+
    hi SpecialKey      ctermfg=59
+   
+   if exists("g:rehash256") && g:rehash256 == 1
+       hi Normal       ctermfg=252 ctermbg=234
+       hi CursorLine               ctermbg=236   cterm=none
+       hi CursorLineNr    ctermfg=226
+
+       hi Boolean         ctermfg=141
+       hi Character       ctermfg=222
+       hi Number          ctermfg=141
+       hi String          ctermfg=222
+       hi Conditional     ctermfg=197               cterm=bold
+       hi Constant        ctermfg=141               cterm=bold
+
+       hi DiffDelete      ctermfg=125 ctermbg=233
+
+       hi Directory       ctermfg=154               cterm=bold
+       hi Error           ctermfg=125 ctermbg=233
+       hi Exception       ctermfg=154               cterm=bold
+       hi Float           ctermfg=141
+       hi Function        ctermfg=154
+       hi Identifier      ctermfg=208
+
+       hi Keyword         ctermfg=197               cterm=bold
+       hi Operator        ctermfg=197
+       hi PreCondit       ctermfg=154               cterm=bold
+       hi PreProc         ctermfg=154
+       hi Repeat          ctermfg=197               cterm=bold
+       
+       hi Statement       ctermfg=197               cterm=bold
+       hi Tag             ctermfg=197
+       hi Title           ctermfg=203
+       hi Visual                      ctermbg=238
+
+       hi Comment         ctermfg=244
+       hi LineNr          ctermfg=239 ctermbg=235
+       hi NonText         ctermfg=239
+       hi SpecialKey      ctermfg=239
+   endif
 end


### PR DESCRIPTION
So, I moved the changes I made to the 256 color version into molokai. so they are only activated with a key (let g:rehash256). I did this simply by adding all my changed lines at the bottom inside of an if statement, meaning these colors are actually being set twice, which, of course, is slightly less efficient. I opted to do it this way because it causes the least amount to disruption to the existing code while adding the fewest number of total lines.

I also added definitions for spell highlighting inside of the preexisting code, because they didn't exist before. You can delete them or move them to my addition if you like. Not a big deal. I may continue making little changes to this for a while (there are still things that could be closer to the GUI colorscheme which I haven't gotten to yet). I'll yank your chain again when I finish tinkering.
