### PR TITLE
Make it easier to follow cursor through matching parens on terminal

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -147,10 +147,10 @@ if &t_Co > 255
    hi Define          ctermfg=81
    hi Delimiter       ctermfg=241
 
-   hi DiffAdd                     ctermbg=24
-   hi DiffChange      ctermfg=181 ctermbg=239
-   hi DiffDelete      ctermfg=162 ctermbg=53
-   hi DiffText                    ctermbg=102 cterm=bold
+   hi DiffAdd         ctermfg=green  ctermbg=none
+   hi DiffChange      ctermfg=yellow ctermbg=none
+   hi DiffDelete      ctermfg=red    ctermbg=none
+   hi DiffText        ctermfg=013    ctermbg=none cterm=none
 
    hi Directory       ctermfg=118               cterm=bold
    hi Error           ctermfg=219 ctermbg=89


### PR DESCRIPTION
Before this change, the matching paren's backgruond matched the 
cursor's background. This made it hard to keep track of the cursor.
To disambiguate, just change the foreground color of the matching
paren.
