### PR TITLE
Foreground/background contrast of the OmniComplete menu for 256 color terminals.

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -177,7 +177,7 @@ if &t_Co > 255
 
    " complete menu
    hi Pmenu           ctermfg=81  ctermbg=16
-   hi PmenuSel                    ctermbg=244
+   hi PmenuSel        ctermfg=253 ctermbg=244
    hi PmenuSbar                   ctermbg=232
    hi PmenuThumb      ctermfg=81
 


### PR DESCRIPTION
In a 256 color terminal the selected entry when using OmniComplete is
barely readable against the light grey background. Tested this under
both xterm and xfce4-terminal. To fix this the foreground for PmenuSel
is set to ctermfg=253.
