### PR TITLE
[master] Change to fenced code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ By default, it has a dark gray background based on the version created by Hamish
 Copy the file on your .vim/colors folder.
 
 If you prefer the scheme to match the original monokai background color, put this in your .vimrc file: 
-    let g:molokai_original = 1
+```
+let g:molokai_original = 1
+```
 
 There is also an alternative sheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
-    let g:rehash256 = 1
+```
+let g:rehash256 = 1
+```
 
 Note: when using the console version, add this command after enabling the colorscheme in your .vimrc:
-    set background=dark
+```
+set background=dark
+```


### PR DESCRIPTION
In README.md, if viewed directly from Github project page, the command is separate on two lines. The `set` and `let` are on the end of the first line. For beginners it would be confusing and they are prone to type wrong commands into `.vimrc`. Now it looks better...
