### PR TITLE
fix #22: 'hi Normal ctermbg=234' sets background=light

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,8 @@ If you prefer the scheme to match the original monokai background color, put thi
 let g:molokai_original = 1
 ```
 
-There is also an alternative sheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
+There is also an alternative scheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
 ```
 let g:rehash256 = 1
 ```
 
-Note: when using the console version, add this command after enabling the colorscheme in your .vimrc:
-```
-set background=dark
-```

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -10,7 +10,6 @@
 
 hi clear
 
-set background=dark
 if version > 580
     " no guarantees for version 5.8 and below, but this makes it stop
     " complaining
@@ -271,3 +270,7 @@ if &t_Co > 255
        hi SpecialKey      ctermfg=239
    endif
 end
+
+" Must be at the end, because of ctermbg=234 bug.
+" https://groups.google.com/forum/#!msg/vim_dev/afPqwAFNdrU/nqh6tOM87QUJ
+set background=dark


### PR DESCRIPTION
~~ugly hack to prevent background=light~~

**update:** a redditor suggested a better fix, which is to simply move the `set bg` statement to the bottom of the syntax file. I've updated the pull request.
