### PR TITLE
Make search highlight more visible

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -76,7 +76,7 @@ hi PreCondit       guifg=#A6E22E               gui=bold
 hi PreProc         guifg=#A6E22E
 hi Question        guifg=#66D9EF
 hi Repeat          guifg=#F92672               gui=bold
-hi Search          guifg=#FFFFFF guibg=#455354
+hi Search          guifg=#FFFFFF guibg=#D75F00
 " marks
 hi SignColumn      guifg=#A6E22E guibg=#232526
 hi SpecialChar     guifg=#F92672               gui=bold
@@ -193,7 +193,7 @@ if &t_Co > 255
    hi PreProc         ctermfg=118
    hi Question        ctermfg=81
    hi Repeat          ctermfg=161               cterm=bold
-   hi Search          ctermfg=253 ctermbg=66
+   hi Search          ctermfg=253 ctermbg=166
 
    " marks column
    hi SignColumn      ctermfg=118 ctermbg=235


### PR DESCRIPTION
The default one is very hard to notice. I guess i'm not the only one who thinks so.
![Screenshot](https://photos-1.dropbox.com/t/0/AADkVq5FoSmPTWRZ4kQI0V0SJJIUWCIqWjwJluBEe-6Qbg/12/14553166/png/2048x1536/3/1396612800/0/2/Screen%20Shot%202014-04-04%20at%2014.21.34.png/ySldTW3VGAsyGxQUvBJndQudsc7KD8BjhfsWrTpeRGA)
