### PR TITLE
Changed Error color to #ff3333 red, better visibility

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -161,7 +161,7 @@ if &t_Co > 255
    hi DiffText                    ctermbg=102 cterm=bold
 
    hi Directory       ctermfg=118               cterm=bold
-   hi Error           ctermfg=219 ctermbg=196
+   hi Error           ctermfg=255 ctermbg=196
    hi ErrorMsg        ctermfg=199 ctermbg=16    cterm=bold
    hi Exception       ctermfg=118               cterm=bold
    hi Float           ctermfg=135


### PR DESCRIPTION
-  Started using this color and really like it, but the error color when checking validation or syntax is very faint.  
  - Error's should stand out
  - Thought others might share the same sentiment
