### PR TITLE
Option to disable italicized text

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ There is also an alternative scheme under development for color terminals which 
 let g:rehash256 = 1
 ```
 
+If italicized text does not show up well with your font, you can disable italics by adding this to your .vimrc:
+```
+let g:molokai_italics = 0
+```

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ let g:rehash256 = 1
 
 If italicized text does not show up well with your font, you can disable italics by adding this to your .vimrc:
 ```
-let g:molokai_italics = 0
+let g:molokai_italic = 0
 ```

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -26,6 +26,11 @@ else
     let s:molokai_original = 0
 endif
 
+if exists("g:molokai_italic")
+    let s:molokai_italic = g:molokai_italic
+else
+    let s:molokai_italic = 1
+endif
 
 hi Boolean         guifg=#AE81FF
 hi Character       guifg=#E6DB74
@@ -41,7 +46,11 @@ hi Delimiter       guifg=#8F8F8F
 hi DiffAdd                       guibg=#13354A
 hi DiffChange      guifg=#89807D guibg=#4C4745
 hi DiffDelete      guifg=#960050 guibg=#1E0010
-hi DiffText                      guibg=#4C4745 gui=italic,bold
+if s:molokai_italic
+    hi DiffText                  guibg=#4C4745 gui=italic,bold
+else
+    hi DiffText                  guibg=#4C4745 gui=bold
+endif
 
 hi Directory       guifg=#A6E22E               gui=bold
 hi Error           guifg=#E6DB74 guibg=#1E0010
@@ -57,8 +66,13 @@ hi IncSearch       guifg=#C4BE89 guibg=#000000
 
 hi Keyword         guifg=#F92672               gui=bold
 hi Label           guifg=#E6DB74               gui=none
-hi Macro           guifg=#C4BE89               gui=italic
-hi SpecialKey      guifg=#66D9EF               gui=italic
+if s:molokai_italic
+    hi Macro       guifg=#C4BE89               gui=italic
+    hi SpecialKey  guifg=#66D9EF               gui=italic
+else
+    hi Macro       guifg=#C4BE89
+    hi SpecialKey  guifg=#66D9EF
+endif
 
 hi MatchParen      guifg=#000000 guibg=#FD971F gui=bold
 hi ModeMsg         guifg=#E6DB74
@@ -80,7 +94,11 @@ hi Search          guifg=#000000 guibg=#FFE792
 hi SignColumn      guifg=#A6E22E guibg=#232526
 hi SpecialChar     guifg=#F92672               gui=bold
 hi SpecialComment  guifg=#7E8E91               gui=bold
-hi Special         guifg=#66D9EF guibg=bg      gui=italic
+if s:molokai_italic
+    hi Special     guifg=#66D9EF guibg=bg      gui=italic
+else
+    hi Special     guifg=#66D9EF guibg=bg
+endif
 if has("spell")
     hi SpellBad    guisp=#FF0000 gui=undercurl
     hi SpellCap    guisp=#7070F0 gui=undercurl
@@ -90,9 +108,17 @@ endif
 hi Statement       guifg=#F92672               gui=bold
 hi StatusLine      guifg=#455354 guibg=fg
 hi StatusLineNC    guifg=#808080 guibg=#080808
-hi StorageClass    guifg=#FD971F               gui=italic
+if s:molokai_italic
+    hi StorageClass guifg=#FD971F              gui=italic
+else
+    hi StorageClass guifg=#FD971F
+endif
 hi Structure       guifg=#66D9EF
-hi Tag             guifg=#F92672               gui=italic
+if s:molokai_italic
+    hi Tag         guifg=#F92672               gui=italic
+else
+    hi Tag         guifg=#F92672
+endif
 hi Title           guifg=#ef5939
 hi Todo            guifg=#FFFFFF guibg=bg      gui=bold
 


### PR DESCRIPTION
In some instances, italicized text does not display well in the GUI.  This adds an option to disable it.
