### PR TITLE
Add option for a transparent background

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,22 @@ If you prefer a transparent background for the terminal version, put this in you
 let g:molokai_transparent = 1
 ```
 
+By default, comments are a very dark gray and not easy to read. To use a dark 
+green instead, put this in your .vimrc file:
+```
+let g:molokai_alternate_comments = 1
+```
+
+
 There is also an alternative scheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
 ```
 let g:rehash256 = 1
 ```
+
+
+## Customisation
+
+If you want to change terminal colors, [this script](https://gist.github.com/MicahElliott/719710)
+converts RGB colors to xterm numbers.
+
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ If you prefer the scheme to match the original monokai background color, put thi
 let g:molokai_original = 1
 ```
 
+If you prefer a transparent background for the terminal version, put this in your .vimrc file:
+```
+let g:molokai_transparent = 1
+```
+
 There is also an alternative scheme under development for color terminals which attempts to bring the 256 color version as close as possible to the the default (dark) GUI version. To access, add this to your .vimrc:
 ```
 let g:rehash256 = 1

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -26,6 +26,12 @@ else
     let s:molokai_original = 0
 endif
 
+if exists("g:molokai_transparent")
+    let s:molokai_transparent = g:molokai_transparent
+else
+    let s:molokai_transparent = 0
+endif
+
 
 hi Boolean         guifg=#AE81FF
 hi Character       guifg=#E6DB74
@@ -138,6 +144,10 @@ if &t_Co > 255
    if s:molokai_original == 1
       hi Normal                   ctermbg=234
       hi CursorLine               ctermbg=235   cterm=none
+      hi CursorLineNr ctermfg=208               cterm=none
+   elseif s:molokai_transparent == 1
+      hi Normal       ctermfg=252 ctermbg=none
+      hi CursorLine               ctermbg=234   cterm=none
       hi CursorLineNr ctermfg=208               cterm=none
    else
       hi Normal       ctermfg=252 ctermbg=233

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -223,7 +223,11 @@ if &t_Co > 255
    hi WarningMsg      ctermfg=231 ctermbg=238   cterm=bold
    hi WildMenu        ctermfg=81  ctermbg=16
 
-   hi Comment         ctermfg=59
+   if exists("g:molokai_alternate_comments") && g:molokai_alternate_comments == 1
+       hi Comment         ctermfg=58
+   else
+       hi Comment         ctermfg=59
+   endif
    hi CursorColumn                ctermbg=236
    hi ColorColumn                 ctermbg=236
    hi LineNr          ctermfg=250 ctermbg=236

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -51,7 +51,7 @@ hi Ignore          guifg=#808080 guibg=bg
 hi IncSearch       guifg=#C4BE89 guibg=#000000
 
 hi Keyword         guifg=#F92672               gui=bold
-hi Label           guifg=#E6DB74               gui=none
+hi Label           guifg=#E6DB74               gui=NONE
 hi Macro           guifg=#C4BE89               gui=italic
 hi SpecialKey      guifg=#66D9EF               gui=italic
 
@@ -92,7 +92,7 @@ hi Title           guifg=#ef5939
 hi Todo            guifg=#FFFFFF guibg=bg      gui=bold
 
 hi Typedef         guifg=#66D9EF
-hi Type            guifg=#66D9EF               gui=none
+hi Type            guifg=#66D9EF               gui=NONE
 hi Underlined      guifg=#808080               gui=underline
 
 hi VertSplit       guifg=#808080 guibg=#080808 gui=bold
@@ -102,13 +102,13 @@ hi WarningMsg      guifg=#FFFFFF guibg=#333333 gui=bold
 hi WildMenu        guifg=#66D9EF guibg=#000000
 
 hi TabLineFill     guifg=#1B1D1E guibg=#1B1D1E
-hi TabLine         guibg=#1B1D1E guifg=#808080 gui=none
+hi TabLine         guibg=#1B1D1E guifg=#808080 gui=NONE
 
 if exists("g:molokai_original") && g:molokai_original == 1
    hi Normal          guifg=#F8F8F2 guibg=#272822
    hi Comment         guifg=#75715E
    hi CursorLine                    guibg=#3E3D32
-   hi CursorLineNr    guifg=#FD971F               gui=none
+   hi CursorLineNr    guifg=#FD971F               gui=NONE
    hi CursorColumn                  guibg=#3E3D32
    hi ColorColumn                   guibg=#3B3A32
    hi LineNr          guifg=#BCBCBC guibg=#3B3A32
@@ -118,7 +118,7 @@ else
    hi Normal          guifg=#F8F8F2 guibg=#1B1D1E
    hi Comment         guifg=#7E8E91
    hi CursorLine                    guibg=#293739
-   hi CursorLineNr    guifg=#FD971F               gui=none
+   hi CursorLineNr    guifg=#FD971F               gui=NONE
    hi CursorColumn                  guibg=#293739
    hi ColorColumn                   guibg=#232526
    hi LineNr          guifg=#465457 guibg=#232526
@@ -132,16 +132,16 @@ end
 if &t_Co > 255
    if exists("g:molokai_original") && g:molokai_original == 1
       hi Normal                   ctermbg=234
-      hi CursorLine               ctermbg=235   cterm=none
-      hi CursorLineNr ctermfg=208               cterm=none
+      hi CursorLine               ctermbg=235   cterm=NONE
+      hi CursorLineNr ctermfg=208               cterm=NONE
    elseif exists("g:molokai_transparent") && g:molokai_transparent == 1
-      hi Normal       ctermfg=252 ctermbg=none
-      hi CursorLine               ctermbg=234   cterm=none
-      hi CursorLineNr ctermfg=208               cterm=none
+      hi Normal       ctermfg=252 ctermbg=NONE
+      hi CursorLine               ctermbg=234   cterm=NONE
+      hi CursorLineNr ctermfg=208               cterm=NONE
    else
       hi Normal       ctermfg=252 ctermbg=233
-      hi CursorLine               ctermbg=234   cterm=none
-      hi CursorLineNr ctermfg=208               cterm=none
+      hi CursorLine               ctermbg=234   cterm=NONE
+      hi CursorLineNr ctermfg=208               cterm=NONE
    endif
    hi Boolean         ctermfg=135
    hi Character       ctermfg=144
@@ -167,12 +167,12 @@ if &t_Co > 255
    hi FoldColumn      ctermfg=67  ctermbg=16
    hi Folded          ctermfg=67  ctermbg=16
    hi Function        ctermfg=118
-   hi Identifier      ctermfg=208               cterm=none
+   hi Identifier      ctermfg=208               cterm=NONE
    hi Ignore          ctermfg=244 ctermbg=232
    hi IncSearch       ctermfg=193 ctermbg=16
 
    hi keyword         ctermfg=161               cterm=bold
-   hi Label           ctermfg=229               cterm=none
+   hi Label           ctermfg=229               cterm=NONE
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
 
@@ -202,7 +202,7 @@ if &t_Co > 255
        hi SpellBad                ctermbg=52
        hi SpellCap                ctermbg=17
        hi SpellLocal              ctermbg=17
-       hi SpellRare  ctermfg=none ctermbg=none  cterm=reverse
+       hi SpellRare  ctermfg=NONE ctermbg=NONE  cterm=reverse
    endif
    hi Statement       ctermfg=161               cterm=bold
    hi StatusLine      ctermfg=238 ctermbg=253
@@ -214,7 +214,7 @@ if &t_Co > 255
    hi Todo            ctermfg=231 ctermbg=232   cterm=bold
 
    hi Typedef         ctermfg=81
-   hi Type            ctermfg=81                cterm=none
+   hi Type            ctermfg=81                cterm=NONE
    hi Underlined      ctermfg=244               cterm=underline
 
    hi VertSplit       ctermfg=244 ctermbg=232   cterm=bold
@@ -237,8 +237,8 @@ if &t_Co > 255
 
    if exists("g:rehash256") && g:rehash256 == 1
        hi Normal       ctermfg=252 ctermbg=234
-       hi CursorLine               ctermbg=236   cterm=none
-       hi CursorLineNr ctermfg=208               cterm=none
+       hi CursorLine               ctermbg=236   cterm=NONE
+       hi CursorLineNr ctermfg=208               cterm=NONE
 
        hi Boolean         ctermfg=141
        hi Character       ctermfg=222

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -224,7 +224,7 @@ if &t_Co > 255
    hi WildMenu        ctermfg=81  ctermbg=16
 
    if exists("g:molokai_alternate_comments") && g:molokai_alternate_comments == 1
-       hi Comment         ctermfg=58
+       hi Comment         ctermfg=60
    else
        hi Comment         ctermfg=59
    endif

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -20,17 +20,6 @@ if version > 580
 endif
 let g:colors_name="molokai"
 
-if exists("g:molokai_original")
-    let s:molokai_original = g:molokai_original
-else
-    let s:molokai_original = 0
-endif
-
-if exists("g:molokai_transparent")
-    let s:molokai_transparent = g:molokai_transparent
-else
-    let s:molokai_transparent = 0
-endif
 
 
 hi Boolean         guifg=#AE81FF
@@ -115,7 +104,7 @@ hi WildMenu        guifg=#66D9EF guibg=#000000
 hi TabLineFill     guifg=#1B1D1E guibg=#1B1D1E
 hi TabLine         guibg=#1B1D1E guifg=#808080 gui=none
 
-if s:molokai_original == 1
+if exists("g:molokai_original") && g:molokai_original == 1
    hi Normal          guifg=#F8F8F2 guibg=#272822
    hi Comment         guifg=#75715E
    hi CursorLine                    guibg=#3E3D32
@@ -141,11 +130,11 @@ end
 " Support for 256-color terminal
 "
 if &t_Co > 255
-   if s:molokai_original == 1
+   if exists("g:molokai_original") && g:molokai_original == 1
       hi Normal                   ctermbg=234
       hi CursorLine               ctermbg=235   cterm=none
       hi CursorLineNr ctermfg=208               cterm=none
-   elseif s:molokai_transparent == 1
+   elseif exists("g:molokai_transparent") && g:molokai_transparent == 1
       hi Normal       ctermfg=252 ctermbg=none
       hi CursorLine               ctermbg=234   cterm=none
       hi CursorLineNr ctermfg=208               cterm=none


### PR DESCRIPTION
This pull request adds the `g:molokai_transparent`. This option removes the default background in the console. There's really just one line changed but maybe other people will use it.
Anyway, if you like it, you can merge it.

I use this with a semi-transparent console and a dark background.
