### PR TITLE
revert MatchParen color changes 

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -177,7 +177,7 @@ if &t_Co > 255
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
 
-   hi MatchParen      ctermfg=233  ctermbg=208 cterm=bold
+   hi MatchParen      ctermfg=208  ctermbg=233 cterm=bold
    hi ModeMsg         ctermfg=229
    hi MoreMsg         ctermfg=229
    hi Operator        ctermfg=161


### PR DESCRIPTION
They make matched parens look exactly the same as the cursor. This is very confusing, so revert that change.
