### PR TITLE
add syntastic error/warning signs

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -76,7 +76,11 @@ hi PreProc         guifg=#A6E22E
 hi Question        guifg=#66D9EF
 hi Repeat          guifg=#F92672               gui=bold
 hi Search          guifg=#000000 guibg=#FFE792
+
 " marks
+hi SyntasticErrorSign   guifg=#F92672 guibg=#232526
+hi SyntasticWarningSign guifg=#E6DB74 guibg=#232526
+
 hi SignColumn      guifg=#A6E22E guibg=#232526
 hi SpecialChar     guifg=#F92672               gui=bold
 hi SpecialComment  guifg=#7E8E91               gui=bold
@@ -195,6 +199,9 @@ if &t_Co > 255
    hi Search          ctermfg=0   ctermbg=222   cterm=NONE
 
    " marks column
+   hi SyntasticErrorSign   ctermfg=161 ctermbg=235
+   hi SyntasticWarningSign ctermfg=144 ctermbg=235
+
    hi SignColumn      ctermfg=118 ctermbg=235
    hi SpecialChar     ctermfg=161               cterm=bold
    hi SpecialComment  ctermfg=245               cterm=bold

--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -80,6 +80,8 @@ hi Search          guifg=#000000 guibg=#FFE792
 " marks
 hi SyntasticErrorSign   guifg=#F92672 guibg=#232526
 hi SyntasticWarningSign guifg=#E6DB74 guibg=#232526
+hi NeomakeErrorSign     guifg=#F92672 guibg=#232526
+hi NeomakeWarningSign   guifg=#E6DB74 guibg=#232526
 
 hi SignColumn      guifg=#A6E22E guibg=#232526
 hi SpecialChar     guifg=#F92672               gui=bold
@@ -201,6 +203,8 @@ if &t_Co > 255
    " marks column
    hi SyntasticErrorSign   ctermfg=161 ctermbg=235
    hi SyntasticWarningSign ctermfg=144 ctermbg=235
+   hi NeomakeErrorSign     ctermfg=161 ctermbg=235
+   hi NeomakeWarningSign   ctermfg=144 ctermbg=235
 
    hi SignColumn      ctermfg=118 ctermbg=235
    hi SpecialChar     ctermfg=161               cterm=bold


### PR DESCRIPTION
This adds colors for the Syntastic warning and error signs.
I used the red of keyword for errors and the yellow of string for warning.
