### PR TITLE
terminal colors: increase "Comment" contrast

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -224,7 +224,7 @@ if &t_Co > 255
    hi WarningMsg      ctermfg=231 ctermbg=238   cterm=bold
    hi WildMenu        ctermfg=81  ctermbg=16
 
-   hi Comment         ctermfg=59
+   hi Comment         ctermfg=243
    hi CursorColumn                ctermbg=236
    hi ColorColumn                 ctermbg=236
    hi LineNr          ctermfg=250 ctermbg=236


### PR DESCRIPTION
The current value for `Comment` on 256-color terminals is painful to read on some terminals because of a lack of contrast. See the attached image for a comparison of the current default (`ctermfg=59`) and the proposed new value (`ctermfg=243`). For comparison `ctermfg=103` is also shown.

I've been using this value on many different terminals and found it to be a good balance. It still keeps Comment fairly subdued without harming readability.

![image](https://cloud.githubusercontent.com/assets/1359421/9773795/859e4712-5712-11e5-9e5f-b3ea3a0c4196.png)
