### PR TITLE
Add molokai_vte option

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -26,6 +26,12 @@ else
     let s:molokai_original = 0
 endif
 
+if exists("g:molokai_vte")
+  let s:molokai_vte = g:molokai_vte
+else
+  let s:molokai_vte = 0
+endif
+
 
 hi Boolean         guifg=#AE81FF
 hi Character       guifg=#E6DB74
@@ -177,7 +183,11 @@ if &t_Co > 255
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
 
-   hi MatchParen      ctermfg=233  ctermbg=208 cterm=bold
+   if s:molokai_vte == 1
+     hi MatchParen      ctermfg=208  ctermbg=233 cterm=bold
+   else
+     hi MatchParen      ctermfg=233  ctermbg=208 cterm=bold
+   endif
    hi ModeMsg         ctermfg=229
    hi MoreMsg         ctermfg=229
    hi Operator        ctermfg=161


### PR DESCRIPTION
As per https://github.com/tomasr/molokai/pull/44, terminal emulators using `libvte` have an issue with `MatchParen` colors, where the cursor seems to disappear when hovering a parenthesis that should be matched.

PR#44 simply changes the colorscheme to prevent this from occurring for all users. This PR adds an option that `libvte` users can enable which prevents the cursor "disappearing" from happening.

I have been using this change for a while and it works like a charm ^_^

Of course, if `libvte` is actually the cause, this fix can most likely be filed as a bug against `libvte`. However, VTE is a relatively large project and until the fix is made, this may be an easier option.

Note that this is also being tracked in a [VTE bug report ](https://bugzilla.gnome.org/show_bug.cgi?id=777952)