### PR TITLE
Changed the cursor enclosing char (ie paren) color

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -177,7 +177,7 @@ if &t_Co > 255
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
 
-   hi MatchParen      ctermfg=233  ctermbg=208 cterm=bold
+   hi MatchParen      ctermfg=81  ctermbg=208 cterm=bold
    hi ModeMsg         ctermfg=229
    hi MoreMsg         ctermfg=229
    hi Operator        ctermfg=161


### PR DESCRIPTION
As discussed in Issue #44 this is a change that would make the visualization of the cursor's position better on the console.