### PR TITLE
Make MatchParen effect visible in linux terminal

### DIFF
--- a/colors/molokai.vim
+++ b/colors/molokai.vim
@@ -177,7 +177,7 @@ if &t_Co > 255
    hi Macro           ctermfg=193
    hi SpecialKey      ctermfg=81
 
-   hi MatchParen      ctermfg=233  ctermbg=208 cterm=bold
+   hi MatchParen      ctermfg=254  ctermbg=208 cterm=bold
    hi ModeMsg         ctermfg=229
    hi MoreMsg         ctermfg=229
    hi Operator        ctermfg=161


### PR DESCRIPTION
Since in Linux terminal the match effect is "reverse" which switch the color of bg and fg causing the black cursor background that's same as the terminal background so that the cursor is not visible.